### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Docker configuration for ApHIN - Autoencoder-based port-Hamiltonian Identification Networks
+# 
+# For end users:
+# ==============
+# Build image:
+# $ docker build -t aphin .
+# 
+# Run container without GUI support:
+# $ docker run -it aphin
+#
+# Run container with GUI support (assuming that the host OS is Linux):
+# $ xhost +local:root
+# $ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" aphin
+# $ xhost -local:root
+#
+# See <https://wiki.ros.org/docker/Tutorials/GUI> for alternative solutions.
+# Similar solutions are available for Windows or macOS as host OS.
+#
+# Alternatively, start the container using docker compose:
+# $ xhost +local:root
+# $ docker compose run aphin
+# $ xhost -local:root
+#
+# Terminate the container with `exit`
+#
+# For developers:
+# ===============
+# Push image to registry (after docker login):
+# $ docker push <insert-organization-here>/aphin
+#####################################
+
+# Set the base image
+# This container uses Tensorflow 2.18.0 without GPU support - Feel free to change to your environment
+FROM tensorflow/tensorflow:2.18.0
+
+# Define variables
+ENV WORKSPACE_DIR="/home"
+ENV PROJECT_DIR="${WORKSPACE_DIR}/aphin"
+ENV GIT_REPO="https://github.com/Institute-Eng-and-Comp-Mechanics-UStgt/ApHIN.git"
+
+# Install dependencies
+RUN apt update && \
+    apt install -y git python3-tk dvipng texlive-latex-extra texlive-fonts-recommended cm-super qt6-base-dev libxcb-cursor0
+
+# Clone demonstrator from GitHub and install dependencies
+RUN cd ${WORKSPACE_DIR} && \
+    git clone ${GIT_REPO} ${PROJECT_DIR} && \
+    cd ${PROJECT_DIR} && \
+    pip install -e .
+
+# Set working directory
+WORKDIR ${PROJECT_DIR}
+
+# Start bash
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,18 @@ FROM tensorflow/tensorflow:2.18.0
 # Define variables
 ENV WORKSPACE_DIR="/home"
 ENV PROJECT_DIR="${WORKSPACE_DIR}/aphin"
-ENV GIT_REPO="https://github.com/Institute-Eng-and-Comp-Mechanics-UStgt/ApHIN.git"
+ENV GITHUB_ORG="Institute-Eng-and-Comp-Mechanics-UStgt"
+ENV GITHUB_REPO="ApHIN"
+ENV GITHUB_BRANCH="main"
 
 # Install dependencies
 RUN apt update && \
     apt install -y git python3-tk dvipng texlive-latex-extra texlive-fonts-recommended cm-super qt6-base-dev libxcb-cursor0
 
 # Clone demonstrator from GitHub and install dependencies
+ADD https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/git/refs/heads/main version.json
 RUN cd ${WORKSPACE_DIR} && \
-    git clone ${GIT_REPO} ${PROJECT_DIR} && \
+    git clone -b ${GITHUB_BRANCH} "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git" ${PROJECT_DIR} && \
     cd ${PROJECT_DIR} && \
     pip install -e .
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ pip install -e .
 
 > :warning: **Please note that you need pip version 24.0 to install the repository in editable mode. Either upgrade pip to the latest version or install it without the ```-e``` argument**
 
+### Docker
+You can use `docker` and `docker compose` to run the ApHIN package with all dependencies in a containerized environment.
+
+#### Build image:
+```bash
+docker build -t aphin .
+```
+ 
+#### Run container without GUI support:
+```bash
+docker run -it aphin
+```
+
+#### Run container with GUI support (assuming that the host OS is Linux):
+```bash
+xhost +local:root
+docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" aphin
+xhost -local:root
+```
+
+See <https://wiki.ros.org/docker/Tutorials/GUI> for alternative solutions.
+Similar solutions are available for Windows or macOS as host OS.
+
+#### Alternatively, start the container using docker compose:
+```bash
+xhost +local:root
+docker compose run aphin
+xhost -local:root
+```
+
+Terminate the container with `exit`.
+
 ## References
 
 [1] Johannes Rettberg, Jonas Kneifl, Julius Herb, Patrick Buchfink, Jörg Fehr, and Bernard Haasdonk. Data-driven identification of latent port-Hamiltonian systems. Arxiv, 2024.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+# The following docker compose configuration is equivalent to running the container via:
+# $ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" aphin
+#
+# Start the container using docker compose:
+# $ xhost +local:root
+# $ docker compose run aphin
+# $ xhost -local:root
+services:
+  aphin:
+    build: .
+    image: aphin
+    container_name: aphin
+    stdin_open: true  # docker run -i
+    tty: true  # docker run -t
+    entrypoint: /bin/bash
+    environment:
+        - DISPLAY
+    volumes:
+        - /tmp/.X11-unix:/tmp/.X11-unix:rw


### PR DESCRIPTION
This PR adds a configuration for `docker` and `docker compose` to run the **ApHIN** package with all dependencies in a containerized environment.

Using `matplotlib` and `PyQt6` with screen output inside a container can be tricky. The usual workaround for Linux-based systems is to expose the X-server domain socket (this is also done here). For Windows and macOS, similar workarounds are possible.